### PR TITLE
Set baseBranch to the proper repo to fix template help button

### DIFF
--- a/plugin/src/main/kotlin/com/almightyalpaca/jetbrains/plugins/discord/plugin/utils/Plugin.kt
+++ b/plugin/src/main/kotlin/com/almightyalpaca/jetbrains/plugins/discord/plugin/utils/Plugin.kt
@@ -29,7 +29,7 @@ object Plugin {
 
     val version: Version? by lazy { plugin?.version?.let { Version(it) } }
 
-    val branchBase = "https://github.com/Almighty-Alpaca/JetBrains-Discord-Integration/blob/" + when (val version = version) {
+    val branchBase = "https://github.com/Azn9/JetBrains-Discord-Integration/blob" + when (val version = version) {
         null -> "master"
         else -> "v" + version.lastStable
     }

--- a/plugin/src/main/kotlin/com/almightyalpaca/jetbrains/plugins/discord/plugin/utils/Plugin.kt
+++ b/plugin/src/main/kotlin/com/almightyalpaca/jetbrains/plugins/discord/plugin/utils/Plugin.kt
@@ -29,7 +29,7 @@ object Plugin {
 
     val version: Version? by lazy { plugin?.version?.let { Version(it) } }
 
-    val branchBase = "https://github.com/Azn9/JetBrains-Discord-Integration/blob" + when (val version = version) {
+    val branchBase = "https://github.com/Azn9/JetBrains-Discord-Integration/blob/" + when (val version = version) {
         null -> "master"
         else -> "v" + version.lastStable
     }


### PR DESCRIPTION
pretty much explained in the title. I set the baseBranch to your repo, so that the (i) button in custom fields links to the proper documentation instead of a missing file.