### PR TITLE
Update README details

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Note : The plugin is not available on the JetBrains plugin repository yet.
 ### ...from the JetBrains Plugin Repository (need to do it manually)
 
 Go to `Setting` -> `Plugin` -> `Manage Plugin Repositories...` click add button and paste
-`https://github.com/Azn9/JetBrains-Discord-Integration/raw/master/update.xml`.
-after this you can search it in Marketplace just like normal plugin.
+`https://github.com/Azn9/JetBrains-Discord-Integration/raw/develop/update.xml`.
+after this you can search it in Marketplace just like normal plugin. It will be named `Discord Integration v2` as a separate plugin.
 
 #### ...from the GitHub release page
 


### PR DESCRIPTION
- Changes specified branch from `master` to `develop` (since you made it the default branch, I assume that is the branch where releases are made)
- Adds more details of what to search for
  - When you changed the group ID, it is now seen as a different plugin, so this is referenced 