### PR TITLE
Update cpp.yaml

### DIFF
--- a/icons/data/languages/cpp.yaml
+++ b/icons/data/languages/cpp.yaml
@@ -12,6 +12,8 @@ match:
       - .h++
       - .hh
       - .hxx
+      - .cppm
+      - .ixx
 
 # TODO: C++
 # .cats


### PR DESCRIPTION
Add CPP Module file extension support so that they don't appear as txt files.
(I don't know if the plugin uses any other files to detect CPP things, if that is the case be sure to let me know!)