### PR TITLE
Fix application code not recognized when using remote development

### DIFF
--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/DataService.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/DataService.kt
@@ -39,6 +39,7 @@ import dev.azn9.plugins.discord.DiscordPlugin
 import dev.azn9.plugins.discord.extensions.VcsInfoExtension
 import dev.azn9.plugins.discord.render.Renderer
 import dev.azn9.plugins.discord.settings.settings
+import dev.azn9.plugins.discord.settings.values.ApplicationType
 import dev.azn9.plugins.discord.settings.values.IdleVisibility.*
 import dev.azn9.plugins.discord.settings.values.ProjectShow
 import dev.azn9.plugins.discord.source.sourceService
@@ -72,7 +73,7 @@ class DataService {
 
         val application = ApplicationManager.getApplication()
         val applicationInfo = ApplicationInfoEx.getInstance()
-        val applicationCode = ApplicationInfo.getInstance().build.productCode
+        val applicationCode = ApplicationType.IDE_EDITION.applicationName
         val applicationName = settings.applicationType.getValue().applicationNameReadable
         val applicationVersion = applicationInfo.fullVersion
         val applicationTimeOpened = application.timeOpened

--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/DataService.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/DataService.kt
@@ -17,7 +17,6 @@
 
 package dev.azn9.plugins.discord.data
 
-import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ex.ApplicationInfoEx
 import com.intellij.openapi.application.runReadAction


### PR DESCRIPTION
when using remote development with for example wsl it will return JBC as the application code which is not what we actually want. I am not entirely sure whether my fix will always return a correct code as i have tested this only with intellij ultimate and the wsl instance. 