### PR TITLE
Fixing the NoSuchFileException by creating the necessary directories

### DIFF
--- a/gradle/plugins/src/main/kotlin/FileIndicesPlugin.kt
+++ b/gradle/plugins/src/main/kotlin/FileIndicesPlugin.kt
@@ -82,6 +82,11 @@ open class GenerateFileIndices : DefaultTask() {
         for (resourceDir in resourceDirs.get().srcDirs) {
             val resourcePath = resourceDir.toPath()
 
+            if (!resourceDir.exists()) {
+                logger.info("$resourceDir does not exist. Creating it.")
+                resourceDir.mkdirs()
+            }
+
             Files.walk(resourcePath)
                 .filter { Files.isRegularFile(it) }
                 .map { resourcePath.relativize(it) }


### PR DESCRIPTION
This Pull Request fixes a NoSuchFileException raised by the `gradle/plugins/src/main/kotlin/FileIndicesPlugin.kt` file.
That exception is raised when a required resource directory is not found. This is fixed by creating the directory.