### PR TITLE
Fix: toolbox application normalization for RPC detection

### DIFF
--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/DataService.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/DataService.kt
@@ -65,10 +65,6 @@ class DataService {
             .getOrNull()
     }
 
-    /**
-     * Normalizes application code to handle Toolbox variants
-     * Removes trailing numbers and underscores (e.g., "rustrover1" -> "rustrover")
-     */
     private fun normalizeApplicationCode(rawCode: String): String {
         val normalized = rawCode.replace(Regex("[_\\d]+$"), "")
         DiscordPlugin.LOG.debug("Normalized application code '$rawCode' -> '$normalized'")
@@ -90,7 +86,6 @@ class DataService {
         val applicationTimeOpened = application.timeOpened
         val applicationTimeActive = application.timeActive
 
-        // Normalize application code to handle Toolbox variants (rustrover1, rustrover2, etc.)
         applicationCode = normalizeApplicationCode(applicationCode)
 
         val project: Project? = IdeFocusManager.getGlobalInstance().lastFocusedFrame?.project

--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/DataService.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/DataService.kt
@@ -53,6 +53,10 @@ val dataService: DataService
 
 @Service
 class DataService {
+    companion object {
+        private val TOOLBOX_SUFFIX_PATTERN = Regex("\\d+$")
+    }
+
     suspend fun getData(mode: Renderer.Mode): Data? = tryOrNull {
         mode.runCatching { getData() }
             .onFailure { e ->
@@ -66,7 +70,7 @@ class DataService {
     }
 
     private fun normalizeApplicationCode(rawCode: String): String {
-        val normalized = rawCode.replace(Regex("[_\\d]+$"), "")
+        val normalized = TOOLBOX_SUFFIX_PATTERN.replace(rawCode, "")
         DiscordPlugin.LOG.debug("Normalized application code '$rawCode' -> '$normalized'")
         return normalized
     }

--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/DataService.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/DataService.kt
@@ -65,6 +65,16 @@ class DataService {
             .getOrNull()
     }
 
+    /**
+     * Normalizes application code to handle Toolbox variants
+     * Removes trailing numbers and underscores (e.g., "rustrover1" -> "rustrover")
+     */
+    private fun normalizeApplicationCode(rawCode: String): String {
+        val normalized = rawCode.replace(Regex("[_\\d]+$"), "")
+        DiscordPlugin.LOG.debug("Normalized application code '$rawCode' -> '$normalized'")
+        return normalized
+    }
+
     @JvmName("getDataInternal")
     private suspend fun (Renderer.Mode).getData(): Data {
         DiscordPlugin.LOG.debug("Getting data")
@@ -79,6 +89,9 @@ class DataService {
         val applicationVersion = applicationInfo.fullVersion
         val applicationTimeOpened = application.timeOpened
         val applicationTimeActive = application.timeActive
+
+        // Normalize application code to handle Toolbox variants (rustrover1, rustrover2, etc.)
+        applicationCode = normalizeApplicationCode(applicationCode)
 
         val project: Project? = IdeFocusManager.getGlobalInstance().lastFocusedFrame?.project
 


### PR DESCRIPTION
Add normalizeApplicationCode() function to handle Toolbox variants. It Fixes Discord Rich Presence not working with Toolbox installation ( rustrover1, intellij_idea2 weren't recognized) which I only noticed recently and thought it was more erroneous but when it said Discord wasn't detected in the panel figured this out. 