### PR TITLE
Fix detection of files incorrectly marked as Gradle

### DIFF
--- a/plugin/changelog.md
+++ b/plugin/changelog.md
@@ -1,3 +1,6 @@
+## v2.1.8
+- Fix detection of files incorrectly marked as Gradle
+
 ## v2.1.7
 - Fix small issues that raise errors without being real errors
 - Fix the webstorm icon not showing with the "macos" icons theme

--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/icons/matcher/Matcher.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/icons/matcher/Matcher.kt
@@ -49,10 +49,10 @@ sealed class Matcher {
     }
 
     enum class Target(val id: String) {
-        PATH("path"),
         NAME("name"),
+        EXTENSION("extension"),
         BASENAME("basename"),
-        EXTENSION("extension");
+        PATH("path");
         // CONTENT("content") // TODO: implement content/magic byte matching
         // EDITOR("editor") // TODO: implement matching the editor type
 


### PR DESCRIPTION
### About:

This PR fixes issue #266 where any file located inside a `.gradle` directory was incorrectly detected as a Gradle file.

### Cause

```kotlin
override fun findLanguage(provider: Matcher.Target.Provider): LanguageMatch {
        for (target in Matcher.Target.values()) { // // PATH is checked before filename or extension
            val fields = provider.getField(target)
            for (language in this) {
                val match = language.findMatch(target, fields)
                if (match != null) {
                    return match
                }
            }
        }

        return default.match
}
```
The `Target` enum was being iterated in the following order: `PATH` -> `NAME` -> `BASENAME` -> `EXTENSION`

```kotlin
enum class Target(val id: String) {
        PATH("path"),
        NAME("name"),
        BASENAME("basename"),
        EXTENSION("extension");
}
```

Because `PATH` was checked first, any file inside a `.gradle` directory was immediately matched as a Gradle file, even if it's extension indicated otherwise. The iteration order follows the declaration order in the enum, so the bug was caused by `PATH` being the first element.

### Solution

The solution was to adjust the order of the enum constants so that filename and extension are checked before the path:

```kotlin
enum class Target(val id: String) {
        NAME("name"),
        EXTENSION("extension"),
        BASENAME("basename"),
        PATH("path");
}
```

## Path
F:\Documents\ClickingCircles\src\test\ `.gradle` \File.java

### Before:
<img width="225" height="117" alt="image" src="https://github.com/user-attachments/assets/6f5569c0-b677-4e73-9e79-1ade004d67ef" />

### After:
<img width="221" height="118" alt="image" src="https://github.com/user-attachments/assets/7e4fd415-0941-4752-97fd-b9f608ba06ef" />

