### PR TITLE
Add .vb as a valid VB.NET extension

### DIFF
--- a/icons/data/languages/visualbasic.yaml
+++ b/icons/data/languages/visualbasic.yaml
@@ -9,6 +9,7 @@ match:
       - .frx # (form - binary information)
       - .ctl # (custom control)
       - .ctx # (custom control binary information)
+      - .vb  # (Visual Basic.NET file)
       - .vbp # (project)
       - .vbg # (project group)
       - .bas # (module)


### PR DESCRIPTION
I presume this was just an omission on your (or the original author's) part. Even though this doesn't solve #284, at least it won't show as "File" then hovering over the icon in Discord.