### PR TITLE
Add buttons to general settings

### DIFF
--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/render/ApplicationRenderer.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/render/ApplicationRenderer.kt
@@ -33,6 +33,10 @@ class ApplicationRenderer(context: RenderContext) : Renderer(context) {
         smallIconCustom = settings.applicationIconSmallCustom,
         smallIconText = settings.applicationIconSmallText,
         smallIconTextCustom = settings.applicationIconSmallTextCustom,
-        startTimestamp = settings.applicationTime
+        startTimestamp = settings.applicationTime,
+        button1Title = settings.button1Text.getValue(),
+        button1Url = settings.button1Url.getValue(),
+        button2Title = settings.button2Text.getValue(),
+        button2Url = settings.button2Url.getValue()
     )
 }

--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/render/FileRenderer.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/render/FileRenderer.kt
@@ -39,10 +39,10 @@ class FileRenderer(context: RenderContext) : Renderer(context) {
             smallIconText = settings.fileIconSmallText,
             smallIconTextCustom = settings.fileIconSmallTextCustom,
             startTimestamp = settings.fileTime,
-            button1Title = projectSettings.button1Title.getValue(),
-            button1Url = projectSettings.button1Url.getValue(),
-            button2Title = projectSettings.button2Title.getValue(),
-            button2Url = projectSettings.button2Url.getValue()
+            button1Title = projectSettings.button1Title.getValue().ifBlank { settings.button1Text.getValue() },
+            button1Url = projectSettings.button1Url.getValue().ifBlank { settings.button1Url.getValue() },
+            button2Title = projectSettings.button2Title.getValue().ifBlank { settings.button2Text.getValue() },
+            button2Url = projectSettings.button2Url.getValue().ifBlank { settings.button2Url.getValue() }
         )
     }
 }

--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/render/ProjectRenderer.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/render/ProjectRenderer.kt
@@ -39,10 +39,10 @@ class ProjectRenderer(context: RenderContext) : Renderer(context) {
             smallIconText = settings.projectIconSmallText,
             smallIconTextCustom = settings.projectIconSmallTextCustom,
             startTimestamp = settings.projectTime,
-            button1Title = projectSettings.button1Title.getValue(),
-            button1Url = projectSettings.button1Url.getValue(),
-            button2Title = projectSettings.button2Title.getValue(),
-            button2Url = projectSettings.button2Url.getValue()
+            button1Title = projectSettings.button1Title.getValue().ifBlank { settings.button1Text.getValue() },
+            button1Url = projectSettings.button1Url.getValue().ifBlank { settings.button1Url.getValue() },
+            button2Title = projectSettings.button2Title.getValue().ifBlank { settings.button2Text.getValue() },
+            button2Url = projectSettings.button2Url.getValue().ifBlank { settings.button2Url.getValue() }
         )
     }
 }

--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/settings/ApplicationSettings.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/settings/ApplicationSettings.kt
@@ -81,6 +81,11 @@ interface ApplicationSettings : PersistentStateComponent<Element>, OptionHolder 
     val fileIconSmallTextCustom: TemplateValue
     val fileTime: TimeValue
 
+    val button1Text: StringValue
+    val button1Url: StringValue
+    val button2Text: StringValue
+    val button2Url: StringValue
+
     val applicationType: ApplicationTypeValue
 
     val applicationTheme: ThemeValue

--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/settings/impl/ApplicationSettingsImpl.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/settings/impl/ApplicationSettingsImpl.kt
@@ -147,6 +147,10 @@ class ApplicationSettingsImpl : ApplicationSettings, PersistentStateOptionHolder
     override val fileHideVcsIgnored by fileTab.check("Hide VCS ignored files", "E.g. files in your .gitignore", false)
 
     /* ========== General Settings ========== */
+    override val button1Text by text("Button 1 title", "")
+    override val button1Url by text("Button 1 url", "")
+    override val button2Text by text("Button 2 title", "")
+    override val button2Url by text("Button 2 url", "")
 
     override val applicationType by selection("Application name", ApplicationType.IDE_EDITION)
 


### PR DESCRIPTION
Unless overriden in the project settings tab, this PR allows users to have general buttons in their presence (same link for every project). Having non-blank buttons in the project's settings will override the general buttons for that specific project.