### PR TITLE
feat: add support for diff editor detection

### DIFF
--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/Data.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/Data.kt
@@ -96,6 +96,7 @@ sealed class Data {
         val filePath: String,
         val fileIsWriteable: Boolean,
         val editorIsTextEditor: Boolean,
+        val isDiffEditor: Boolean,
         val caretLine: Int,
         val lineCount: Int,
         val moduleName: String?,
@@ -141,7 +142,7 @@ sealed class Data {
         }
 
         override fun toString(): String {
-            return "Data.File(applicationName='$applicationName', applicationVersion='$applicationVersion', applicationTimeOpened=$applicationTimeOpened, applicationTimeActive=$applicationTimeActive, projectName='$projectName', projectDescription='$projectDescription', projectTimeOpened=$projectTimeOpened, projectTimeActive=$projectTimeActive, vcsBranch=$vcsBranch, fileName='$fileName', fileNameUnique='$fileNameUnique', fileTimeOpened=$fileTimeOpened, fileTimeActive=$fileTimeActive, filePath='$filePath', fileIsWriteable=$fileIsWriteable, editorIsTextEditor=$editorIsTextEditor, caretLine=$caretLine, lineCount=$lineCount, moduleName=$moduleName, pathInModule=$pathInModule, fileSize=$fileSize)"
+            return "Data.File(applicationName='$applicationName', applicationVersion='$applicationVersion', applicationTimeOpened=$applicationTimeOpened, applicationTimeActive=$applicationTimeActive, projectName='$projectName', projectDescription='$projectDescription', projectTimeOpened=$projectTimeOpened, projectTimeActive=$projectTimeActive, vcsBranch=$vcsBranch, fileName='$fileName', fileNameUnique='$fileNameUnique', fileTimeOpened=$fileTimeOpened, fileTimeActive=$fileTimeActive, filePath='$filePath', fileIsWriteable=$fileIsWriteable, editorIsTextEditor=$editorIsTextEditor, isDiffEditor=$isDiffEditor, caretLine=$caretLine, lineCount=$lineCount, moduleName=$moduleName, pathInModule=$pathInModule, fileSize=$fileSize)"
         }
     }
 }

--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/DataService.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/DataService.kt
@@ -27,6 +27,7 @@ import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.fileEditor.UniqueVFilePathBuilder
+import com.intellij.openapi.fileEditor.impl.EditorTabTitleProvider
 import com.intellij.openapi.module.ModuleUtil
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
@@ -55,6 +56,7 @@ val dataService: DataService
 class DataService {
     companion object {
         private val TOOLBOX_SUFFIX_PATTERN = Regex("\\d+$")
+        private val FILENAME_PATTERN = Regex("""\b[\w\-]+\.[\w.]+\b""")
     }
 
     suspend fun getData(mode: Renderer.Mode): Data? = tryOrNull {
@@ -181,12 +183,31 @@ class DataService {
                         && project.settings.show.getValue() >= ProjectShow.PROJECT_FILES
                         && !(settings.fileHideVcsIgnored.getValue() && isVcsIgnored(project, file))
                     ) {
-                        val fileName = file.name
-                        val fileUniqueName = when (DumbService.isDumb(project)) {
-                            true -> fileName
-                            false -> invokeReadAction {
-                                tryOrDefault(fileName, false) {
-                                    UniqueVFilePathBuilder.getInstance().getUniqueVirtualFilePath(project, file)
+                        val isDiffEditor = editor.javaClass.name.contains("Diff") ||
+                                           file.javaClass.name.contains("DiffVirtualFile")
+
+                        val fileName: String
+                        val fileUniqueName: String
+                        if (isDiffEditor) {
+                            val diffName = tryOrNull {
+                                EditorTabTitleProvider.EP_NAME.extensionList
+                                    .asSequence()
+                                    .mapNotNull { it.getEditorTabTooltipText(project, file) }
+                                    .firstOrNull { it.isNotEmpty() && it != file.name }
+                                    ?.let { title ->
+                                        FILENAME_PATTERN.find(title)?.value ?: title
+                                    }
+                            }
+                            fileName = diffName ?: file.name
+                            fileUniqueName = fileName
+                        } else {
+                            fileName = file.name
+                            fileUniqueName = when (DumbService.isDumb(project)) {
+                                true -> fileName
+                                false -> invokeReadAction {
+                                    tryOrDefault(fileName, false) {
+                                        UniqueVFilePathBuilder.getInstance().getUniqueVirtualFilePath(project, file)
+                                    }
                                 }
                             }
                         }
@@ -248,6 +269,7 @@ class DataService {
                             filePath,
                             fileIsWriteable,
                             editorIsTextEditor,
+                            isDiffEditor,
                             caretLine,
                             lineCount,
                             moduleData.moduleName,

--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/DataService.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/DataService.kt
@@ -56,7 +56,7 @@ val dataService: DataService
 class DataService {
     companion object {
         private val TOOLBOX_SUFFIX_PATTERN = Regex("\\d+$")
-        private val FILENAME_PATTERN = Regex("""\b[\w\-]+\.[\w.]+\b""")
+        private val FILENAME_PATTERN = Regex("""\b[\w\-]+(?:\.[\w\-]+)+\b""")
     }
 
     suspend fun getData(mode: Renderer.Mode): Data? = tryOrNull {

--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/DataService.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/data/DataService.kt
@@ -195,7 +195,7 @@ class DataService {
                                     .mapNotNull { it.getEditorTabTooltipText(project, file) }
                                     .firstOrNull { it.isNotEmpty() && it != file.name }
                                     ?.let { title ->
-                                        FILENAME_PATTERN.find(title)?.value ?: title
+                                        FILENAME_PATTERN.find(title)?.value
                                     }
                             }
                             fileName = diffName ?: file.name

--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/render/templates/CustomTemplate.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/render/templates/CustomTemplate.kt
@@ -46,6 +46,7 @@ object Utils {
             "Language" -> context.language
             "FileSize" -> sizeAsString(context.fileData?.fileSize)
             "IsTextEditor" -> context.fileData?.editorIsTextEditor.toString()
+            "IsDiffEditor" -> context.fileData?.isDiffEditor.toString()
             "FileIsWritable" -> context.fileData?.fileIsWriteable.toString()
             "DebuggerActive" -> context.projectData?.debuggerActive.toString()
             else -> null
@@ -212,6 +213,7 @@ private fun Data.asTemplateData(): TemplateData =
                 this.filePath,
                 this.fileIsWriteable,
                 this.editorIsTextEditor,
+                this.isDiffEditor,
                 this.caretLine,
                 this.lineCount,
                 this.moduleName,
@@ -263,6 +265,7 @@ sealed class TemplateData {
         val filePath: String,
         val fileIsWriteable: Boolean,
         val editorIsTextEditor: Boolean,
+        val isDiffEditor: Boolean,
 
         val caretLine: Int,
         val lineCount: Int,

--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/settings/gui/preview/PreviewRenderer.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/settings/gui/preview/PreviewRenderer.kt
@@ -513,6 +513,7 @@ private fun Data.completeMissingData(): Data.File {
         file?.filePath ?: "dummy/$dummyFileName",
         file?.fileIsWriteable ?: true,
         file?.editorIsTextEditor ?: false,
+        file?.isDiffEditor ?: false,
         file?.caretLine ?: 0,
         file?.lineCount ?: 0,
         file?.moduleName ?: "dummy-module",

--- a/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/settings/values/PresenceText.kt
+++ b/plugin/common/src/main/kotlin/dev/azn9/plugins/discord/settings/values/PresenceText.kt
@@ -201,9 +201,10 @@ enum class PresenceText(override val text: String, override val description: Str
 
 private fun RenderContext.getPrefix(file: Data.File): String {
     return when (settings.filePrefixEnabled.getValue()) {
-        true -> when (file.fileIsWriteable) {
-            true -> "Editing "
-            false -> "Reading "
+        true -> when {
+            file.isDiffEditor -> "Comparing "
+            file.fileIsWriteable -> "Editing "
+            else -> "Reading "
         }
 
         false -> ""

--- a/plugin/templates.adoc
+++ b/plugin/templates.adoc
@@ -20,6 +20,7 @@ Here is a list of all the variables that you can use:
 - `${FileSize}`/`$FileSize`: The size of the file currently open in the editor, in human readable format(appends "bytes", "KiB", "MiB" and "GiB", depending on the size of it).
 - `${FileIsWritable}/$FileIsWritable`: `true` if the currently edited file isn't readonly and `false` otherwise. Meant to be used with `%if`.
 - `${IsTextEditor}`/`$IsTextEditor`: `true` if the currently opened editor is a text editor. Meant to be used with `%if`.
+- `${IsDiffEditor}`/`$IsDiffEditor`: `true` if the currently opened editor is a diff editor (e.g. comparing two files or revisions). Meant to be used with `%if`.
 - `${DebbuggerActive}`/`$DebuggerActive`: `true` if the current project is in a debugging session. Meant to be used with `%if`.
 
 === Availability in different contexts
@@ -95,6 +96,11 @@ Here is a list of all the variables that you can use:
 | Available
 
 | `$IsTextEditor`
+| Not available
+| Not available
+| Available
+
+| `$IsDiffEditor`
 | Not available
 | Not available
 | Available


### PR DESCRIPTION
This PR adds support for viewing diffs by updating status to "Comparing `filename`" when viewing diffs

## Original Behavior

The following would appear when the following was open:

<img width="1188" height="466" alt="image" src="https://github.com/user-attachments/assets/72482fb7-6e50-4014-a51f-632bb967ec31" />

<img width="469" height="257" alt="image" src="https://github.com/user-attachments/assets/3e7fef5f-ccd4-4f46-908b-eba4c335a67d" />

## New Behavior

We employ a new technique for capturing filename when reading a diff.

<img width="1186" height="435" alt="image" src="https://github.com/user-attachments/assets/9455173e-6fad-448a-93fc-c2dd519779bd" />

<img width="462" height="191" alt="image" src="https://github.com/user-attachments/assets/32004b68-c943-410c-b101-651dd4a03a78" />

This also works with diffs generated by Claude Code, Junie through their native integrations.

<img width="1616" height="647" alt="image" src="https://github.com/user-attachments/assets/bcda28f7-71f5-4e7f-bc01-9fc386623e2c" />

<img width="1039" height="302" alt="image" src="https://github.com/user-attachments/assets/521935fc-8bd1-4f30-9ec3-e7d66f197cd7" />

<img width="462" height="187" alt="image" src="https://github.com/user-attachments/assets/944f0346-3915-4c87-aad8-8818f35a2c56" />

